### PR TITLE
allow multiple exec calls for a single connection

### DIFF
--- a/lib/telnet-client.js
+++ b/lib/telnet-client.js
@@ -179,7 +179,7 @@ telnet.prototype.exec = function(cmd, callback) {
         }, self.execTimeout);
       }
 
-      self.on('response', function() {
+      self.once('response', function() {
         if(this.debug) {
           log('Response ready with:');
           log(this.response);
@@ -197,6 +197,7 @@ telnet.prototype.exec = function(cmd, callback) {
         }
 
         callback(null, response);
+        next();
       });
     });
   });


### PR DESCRIPTION
Guys, it's a critical fix for a great bug.
Cause it's not usable - send only one exec per connection session.
With this changes multiple exec calls working, i've tested.
